### PR TITLE
Added backward compaitability

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticator.java
@@ -341,10 +341,17 @@ public class FacebookAuthenticator extends AbstractApplicationAuthenticator impl
             Map<ClaimMapping, String> claims = new HashMap<>();
             String claimUri;
             Object claimValueObject;
+            String claimDialectUri = getClaimDialectURI();
+            if (claimDialectUri == null) {
+                claimDialectUri = "";
+            } else {
+                claimDialectUri += "/";
+            }
 
             for (Map.Entry<String, Object> userInfo : jsonObject.entrySet()) {
                 claimUri            = userInfo.getKey();
                 claimValueObject    = userInfo.getValue();
+                claimUri            = claimDialectUri + claimUri;
                 if (StringUtils.isNotEmpty(claimUri) && claimValueObject != null && StringUtils.isNotEmpty(
                         claimValueObject.toString())) {
                     claims.put(buildClaimMapping(claimUri),claimValueObject.toString());
@@ -425,18 +432,23 @@ public class FacebookAuthenticator extends AbstractApplicationAuthenticator impl
 
     @Override
     public String getClaimDialectURI() {
-        return FacebookAuthenticatorConstants.CLAIM_DIALECT_URI;
+        String claimDialectUri = super.getClaimDialectURI();
+        if (StringUtils.isNotEmpty(claimDialectUri)) {
+            return claimDialectUri;
+        } else {
+            return null;
+        }
     }
 
     protected ClaimMapping buildClaimMapping(String claimUri) {
+        ClaimMapping claimMapping = new ClaimMapping();
+        Claim claim = new Claim();
+        claim.setClaimUri(claimUri);
+        claimMapping.setRemoteClaim(claim);
+        claimMapping.setLocalClaim(claim);
         if (log.isDebugEnabled()) {
             log.debug("Adding claim mapping" + claimUri);
         }
-        ClaimMapping claimMapping = new ClaimMapping();
-        Claim claim = new Claim();
-        claim.setClaimUri(FacebookAuthenticatorConstants.CLAIM_DIALECT_URI + "/" + claimUri);
-        claimMapping.setRemoteClaim(claim);
-        claimMapping.setLocalClaim(claim);
         return claimMapping;
     }
 


### PR DESCRIPTION
This PR intend to add backward compaitability for facebook connector. To add dedicated claim dialect support, configure the application-authentication.xml as below.

ex :- &lt;Parameter name="ClaimDialectUri"&gt;http://wso2.org/facebook/claims &lt;/Parameter&gt;

After that add dedicated claim dialect in management console with above given uri and relevant mapping
Public Jira :- https://wso2.org/jira/browse/IDENTITY-6239