### PR TITLE
Added dedicated claim dialect support without changing the authentication framework

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticator.java
@@ -425,18 +425,30 @@ public class FacebookAuthenticator extends AbstractApplicationAuthenticator impl
 
     @Override
     public String getClaimDialectURI() {
-        return FacebookAuthenticatorConstants.CLAIM_DIALECT_URI;
+        String claimDialectUri = super.getClaimDialectURI();
+        if (StringUtils.isNotEmpty(claimDialectUri)) {
+            return claimDialectUri;
+        } else {
+            return null;
+        }
     }
 
     protected ClaimMapping buildClaimMapping(String claimUri) {
+        ClaimMapping claimMapping = new ClaimMapping();
+        Claim claim = new Claim();
+        String claimDialectUri = getClaimDialectURI();
+        if (claimDialectUri == null) {
+            claimDialectUri = "";
+        } else {
+            claimDialectUri += "/";
+        }
+        claimUri =  claimDialectUri + claimUri;
+        claim.setClaimUri(claimUri);
+        claimMapping.setRemoteClaim(claim);
+        claimMapping.setLocalClaim(claim);
         if (log.isDebugEnabled()) {
             log.debug("Adding claim mapping" + claimUri);
         }
-        ClaimMapping claimMapping = new ClaimMapping();
-        Claim claim = new Claim();
-        claim.setClaimUri(FacebookAuthenticatorConstants.CLAIM_DIALECT_URI + "/" + claimUri);
-        claimMapping.setRemoteClaim(claim);
-        claimMapping.setLocalClaim(claim);
         return claimMapping;
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorConstants.java
@@ -39,8 +39,7 @@ public class FacebookAuthenticatorConstants {
     public static final String FB_CALLBACK_URL = "callBackUrl";
 
     public static final String FB_ACCESS_TOKEN = "access_token";
-
-    public static final String CLAIM_DIALECT_URI = "http://wso2.org/facebook/claims";
+    public static final String CLAIM_DIALECT_URI_PARAMETER = "FacebookClaimDialectUri";
 
     private FacebookAuthenticatorConstants() {
     }


### PR DESCRIPTION
This PR intends to add dedicated claim dialect support with backward compatibility. In order to activate it, the application-authentication.xml needs to be configured as below.
&lt;Parameter name="FacebookClaimDialectUri"&gt;http://wso2.org/facebook/claims &lt;/Parameter&gt;

public Jira :- https://wso2.org/jira/browse/IDENTITY-6239