### PR TITLE
Fixed #2289 : Facebook authenticator fails if "Not now" is clicked without providing credentials

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorConstants.java
@@ -25,6 +25,10 @@ public class FacebookAuthenticatorConstants {
 
     public static final String OAUTH2_GRANT_TYPE_CODE = "code";
     public static final String OAUTH2_PARAM_STATE = "state";
+    public static final String OAUTH2_PARAM_ERROR = "error";
+    public static final String OAUTH2_PARAM_ERROR_CODE = "error_code";
+    public static final String OAUTH2_PARAM_ERROR_DESCRIPTION = "error_description";
+    public static final String OAUTH2_PARAM_ERROR_REASON = "error_reason";
     public static final String EMAIL = "email";
 
     public static final String SCOPE = "Scope";

--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorTests.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorTests.java
@@ -115,8 +115,6 @@ public class FacebookAuthenticatorTests {
             { /* define in static block */
                 mockHttpServletRequest.getParameter(FacebookAuthenticatorConstants.OAUTH2_PARAM_STATE);
                 result = null;
-                mockHttpServletRequest.getParameter(FacebookAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE);
-                result = "Authorization";
             }
         };
         Assert.assertEquals(facebookAuthenticator.canHandle(mockHttpServletRequest), false);
@@ -125,8 +123,17 @@ public class FacebookAuthenticatorTests {
             { /* define in static block */
                 mockHttpServletRequest.getParameter(FacebookAuthenticatorConstants.OAUTH2_PARAM_STATE);
                 result = TestConstants.dummyCommonAuthId + ",nothing";
+            }
+        };
+        Assert.assertEquals(facebookAuthenticator.canHandle(mockHttpServletRequest), false);
+        new Expectations() {
+            { /* define in static block */
+                mockHttpServletRequest.getParameter(FacebookAuthenticatorConstants.OAUTH2_PARAM_STATE);
+                result = TestConstants.dummyCommonAuthId + ",facebook";
+                mockHttpServletRequest.getParameter(FacebookAuthenticatorConstants.OAUTH2_PARAM_ERROR);
+                result = null;
                 mockHttpServletRequest.getParameter(FacebookAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE);
-                result = "someString";
+                result = null;
             }
         };
         Assert.assertEquals(facebookAuthenticator.canHandle(mockHttpServletRequest), false);

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
 
     <properties>
         <!--Carbon framework version-->
-        <carbon.identity.framework.version>5.5.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.7.5</carbon.identity.framework.version>
         <identity.outbound.auth.facebook.export.version>${project.version}</identity.outbound.auth.facebook.export.version>
         <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
### When should this PR be merged
### Follow up actions
### Checklist (for reviewing)
#### General
#### Functionality
#### Code
#### Tests
#### Security
#### Documentation