### PR TITLE
Change JIT provisioned Managed profile name

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticator.java
@@ -589,7 +589,7 @@ public class FacebookAuthenticator extends AbstractApplicationAuthenticator impl
 
     @Override
     public String getFriendlyName() {
-        return "facebook";
+        return FacebookAuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorConstants.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.authenticator.facebook;
 public class FacebookAuthenticatorConstants {
 
     public static final String AUTHENTICATOR_NAME = "FacebookAuthenticator";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "Facebook";
     public static final String FACEBOOK_LOGIN_TYPE = "facebook";
 
     public static final String OAUTH2_GRANT_TYPE_CODE = "code";

--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorTests.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorTests.java
@@ -236,7 +236,7 @@ public class FacebookAuthenticatorTests {
     public void testAuthenticatorNames() {
         Assert.assertEquals(facebookAuthenticator.getName(), FacebookAuthenticatorConstants.AUTHENTICATOR_NAME, "FB " +
                 "Authenticator did not return expected name");
-        Assert.assertEquals(facebookAuthenticator.getFriendlyName(), "facebook", "FB authenticator did not return " +
+        Assert.assertEquals(facebookAuthenticator.getFriendlyName(), "Facebook", "FB authenticator did not return " +
                 "expected friendly name");
     }
 


### PR DESCRIPTION
Related https://github.com/wso2-enterprise/asgardeo-product/issues/5963

Change the `AUTHENTICATOR_FRIENDLY_NAME` constant of Facebook Authenticator as the `Facebook`.