### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <url>https://github.com/wso2-extensions/identity-outbound-auth-facebook.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-outbound-auth-facebook.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-outbound-auth-facebook.git</connection>
-        <tag>v5.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 
@@ -214,12 +214,12 @@
 
     <properties>
         <!--Carbon framework version-->
-        <carbon.identity.framework.version>5.7.5</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
         <identity.outbound.auth.facebook.export.version>${project.version}</identity.outbound.auth.facebook.export.version>
-        <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
+        <carbon.identity.framework.import.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.import.version.range>
 
-        <identity.outbound.auth.oidc.version>5.1.3</identity.outbound.auth.oidc.version>
-        <identity.outbound.auth.oidc.import.version.range>[5.0.0, 6.0.0)</identity.outbound.auth.oidc.import.version.range>
+        <identity.outbound.auth.oidc.version>6.0.0</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.import.version.range>[6.0.0, 7.0.0)</identity.outbound.auth.oidc.import.version.range>
 
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.4.7</carbon.kernel.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16