### PR TITLE
Tenant qualify default commonauth URL

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/pom.xml
@@ -108,6 +108,8 @@
                             version="${carbon.identity.framework.import.version.range}",
                             org.wso2.carbon.identity.application.authenticator.oidc;
                             version="${identity.outbound.auth.oidc.import.version.range}",
+                            org.wso2.carbon.identity.core;
+                            version="${carbon.identity.framework.import.version.range}",
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.framework.import.version.range}",
                             org.wso2.carbon.identity.central.log.mgt.utils;

--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorTests.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorTests.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
@@ -43,6 +44,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authenticator.facebook.TestUtils.mockLoggerUtils;
+import static org.wso2.carbon.identity.application.authenticator.facebook.TestUtils.mockServiceURLBuilder;
 
 public class FacebookAuthenticatorTests {
 
@@ -62,6 +64,8 @@ public class FacebookAuthenticatorTests {
     private OAuthClientRequest.TokenRequestBuilder mockTokenRequestBuilder;
     @Mocked
     private LoggerUtils mockLoggerUtils;
+    @Mocked
+    private ServiceURLBuilder mockServiceURLBuilder;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -321,13 +325,8 @@ public class FacebookAuthenticatorTests {
     public void testInitiateAuthReqWithDefaultConfigs() throws Exception {
 
         final String[] redirectedUrl = new String[1];
-        final String customHost = "https://somehost:9443/commonauth";
-        new Expectations() {
-            { /* define in static block */
-                mockIdentityUtil.getServerURL(anyString, anyBoolean, anyBoolean);
-                result = customHost;
-            }
-        };
+
+        mockServiceURLBuilder(mockServiceURLBuilder);
         buildExpectationsForInitiateReq(null, null, null);
         new Expectations() {{
             mockHttpServletResponse.sendRedirect(anyString);

--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookProcessResponseTests.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookProcessResponseTests.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
@@ -45,6 +46,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authenticator.facebook.TestUtils.mockLoggerUtils;
+import static org.wso2.carbon.identity.application.authenticator.facebook.TestUtils.mockServiceURLBuilder;
 
 public class FacebookProcessResponseTests {
 
@@ -69,6 +71,8 @@ public class FacebookProcessResponseTests {
     private ClaimConfig mockClaimConfig;
     @Mocked
     private LoggerUtils mockLoggerUtils;
+    @Mocked
+    private ServiceURLBuilder mockServiceURLBuilder;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -87,8 +91,8 @@ public class FacebookProcessResponseTests {
     @Test(expectedExceptions = AuthenticationFailedException.class)
     public void testProcessAuthResponseWithFailedTokenReq() throws Exception {
 
-        mockIdentityUtil();
         mockLoggerUtils(mockLoggerUtils);
+        mockServiceURLBuilder(mockServiceURLBuilder);
         new Expectations() {
             {
                 mockAuthzResponse.oauthCodeAuthzResponse((HttpServletRequest) withNotNull());
@@ -107,8 +111,8 @@ public class FacebookProcessResponseTests {
     public void testProcessAuthResponseWithCode() throws Exception {
 
         TestUtils.enableDebugLogs(mockedLog, FacebookAuthenticator.class);
-        mockIdentityUtil();
         mockLoggerUtils(mockLoggerUtils);
+        mockServiceURLBuilder(mockServiceURLBuilder);
         mockTokenAndUserInfoCalls(TestConstants.tokenResponse, TestConstants.userInfoResponse);
         new Expectations() {
             {
@@ -132,8 +136,8 @@ public class FacebookProcessResponseTests {
     @Test(expectedExceptions = AuthenticationFailedException.class)
     public void testProcessAuthResponseWithErrorTokenResponse() throws Exception {
 
-        mockIdentityUtil();
         mockLoggerUtils(mockLoggerUtils);
+        mockServiceURLBuilder(mockServiceURLBuilder);
         mockTokenAndUserInfoCalls(TestConstants.tokenResponse.replace("$token", ""), TestConstants.userInfoResponse);
         new Expectations() {
             {

--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/TestUtils.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/test/java/org/wso2/carbon/identity/application/authenticator/facebook/TestUtils.java
@@ -18,9 +18,16 @@
 
 package org.wso2.carbon.identity.application.authenticator.facebook;
 
+import mockit.Delegate;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.commons.logging.Log;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.ServiceURL;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -51,6 +58,32 @@ public class TestUtils {
         new Expectations(LoggerUtils.class) {{
             mockLoggerUtils.triggerDiagnosticLogEvent(withNotNull());
             minTimes = 0;
+        }};
+    }
+
+    public static void mockServiceURLBuilder(ServiceURLBuilder mockServiceURLBuilder) throws URLBuilderException {
+
+        final String customHost = "https://somehost:9443/commonauth";
+
+        new Expectations() {{
+            ServiceURLBuilder.create();
+            result = mockServiceURLBuilder;
+
+            mockServiceURLBuilder.addPath(FrameworkConstants.COMMONAUTH);
+            result = mockServiceURLBuilder;
+
+            mockServiceURLBuilder.build();
+            result = new Delegate<ServiceURL>() {
+                ServiceURL delegateBuild() {
+                    ServiceURL serviceURL = new MockUp<ServiceURL>() {
+                        @Mock
+                        String getAbsolutePublicURL() {
+                            return customHost;
+                        }
+                    }.getMockInstance();
+                    return serviceURL;
+                }
+            };
         }};
     }
 }


### PR DESCRIPTION
If the commonauth URL is not configured in the Identity provider, the default commonauth URL will be resolved internally. This PR uses the ServerURLBuilder to build this with the tenant domain to support tenant qualified URLs.

Related issue: https://github.com/wso2/product-is/issues/9006