### PR TITLE
Fix facebook login failure issue

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticator.java
@@ -401,21 +401,32 @@ public class FacebookAuthenticator extends AbstractApplicationAuthenticator impl
                         "obtaining claim configurations");
             }
             if (StringUtils.isNotBlank(userInfoFields)) {
-                String userClaimUri = claimConfig.getUserClaimURI();
-                if (StringUtils.isNotBlank(userClaimUri)) {
-                    if (!Arrays.asList(userInfoFields.split(",")).contains(userClaimUri) && !claimConfig
-                            .isLocalClaimDialect()) {
-                        userInfoFields += ("," + userClaimUri);
-                        if (log.isDebugEnabled()) {
-                            log.debug("Adding user claim uri " + userClaimUri + " into the user info fields in " +
-                                    "authenticator");
-                        }
-                    }
-                } else {
-                    if (!Arrays.asList(userInfoFields.split(",")).contains(FacebookAuthenticatorConstants
-                            .DEFAULT_USER_IDENTIFIER)) {
-                        userInfoFields += ("," + FacebookAuthenticatorConstants.DEFAULT_USER_IDENTIFIER);
-                    }
+                /**
+                 * The below code is commented because of facebook login failure issue.
+                 * Once the issue https://github.com/wso2/product-is/issues/20336 is fixed,
+                 * please update the commented code segment
+                 */
+//                String userClaimUri = claimConfig.getUserClaimURI();
+//                if (StringUtils.isNotBlank(userClaimUri)) {
+//                    if (!Arrays.asList(userInfoFields.split(",")).contains(userClaimUri) && !claimConfig
+//                            .isLocalClaimDialect()) {
+//                        userInfoFields += ("," + userClaimUri);
+//                        if (log.isDebugEnabled()) {
+//                            log.debug("Adding user claim uri " + userClaimUri + " into the user info fields in " +
+//                                    "authenticator");
+//                        }
+//                    }
+//                } else {
+//                    if (!Arrays.asList(userInfoFields.split(",")).contains(FacebookAuthenticatorConstants
+//                            .DEFAULT_USER_IDENTIFIER)) {
+//                        userInfoFields += ("," + FacebookAuthenticatorConstants.DEFAULT_USER_IDENTIFIER);
+//                    }
+//                }
+                // This code was extracted from line 415-418. Once above code is uncommented,
+                // please remove the below code segment
+                if (!Arrays.asList(userInfoFields.split(",")).contains(FacebookAuthenticatorConstants
+                        .DEFAULT_USER_IDENTIFIER)) {
+                    userInfoFields += ("," + FacebookAuthenticatorConstants.DEFAULT_USER_IDENTIFIER);
                 }
             }
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;


### PR DESCRIPTION
### Proposed changes in this pull request

Fix facebook login failure issue

The issue is when login to facebook, the fb authenticator tries to get the user info. In that call, we send http://wso2.org/username claim. But since this claim is not a default support claim by facebook, we are getting a 400 as the error response. 
This PR will comment out the code segment that add this claim to the requested fields. 

### Related Issues: 
- https://github.com/wso2/product-is/issues/20336
