### PR TITLE
Extends authentication executor

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookExecutor.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServerException;
+import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
@@ -68,7 +69,7 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorS
 /**
  * Facebook Executor for handling the OAuth2 login flow.
  */
-public class FacebookExecutor implements Executor {
+public class FacebookExecutor extends AuthenticationExecutor {
 
     private static final Log LOG = LogFactory.getLog(FacebookExecutor.class);
     private static final String EXECUTOR_NAME = "FacebookExecutor";
@@ -79,6 +80,12 @@ public class FacebookExecutor implements Executor {
     public String getName() {
 
         return EXECUTOR_NAME;
+    }
+
+    @Override
+    public String getAMRValue() {
+
+        return FacebookAuthenticatorConstants.AUTHENTICATOR_NAME;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
 
     <properties>
         <!--Carbon framework version-->
-        <carbon.identity.framework.version>7.8.228</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
         <identity.outbound.auth.facebook.export.version>${project.version}</identity.outbound.auth.facebook.export.version>
         <carbon.identity.framework.import.version.range>[5.25.260, 8.0.0)</carbon.identity.framework.import.version.range>
 


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

This pull request updates the Facebook authenticator to align with the latest authentication flow engine and adds support for Authentication Method Reference (AMR) values. The main changes involve updating the base class for `FacebookExecutor`, implementing AMR value retrieval, and bumping the Carbon framework version for compatibility.

Authentication flow integration:

* Changed `FacebookExecutor` to extend `AuthenticationExecutor` instead of implementing `Executor`, ensuring it uses the latest authentication flow engine features.
* Imported `AuthenticationExecutor` in `FacebookExecutor.java` to support the new base class.

AMR support:

* Added the `getAMRValue()` method to `FacebookExecutor`, returning the authenticator name for AMR tracking.

Dependency update:

* Upgraded the Carbon framework version from `7.8.228` to `7.8.403` in `pom.xml` for compatibility with new features.